### PR TITLE
feat: add client-side routing

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,0 +1,2 @@
+/api/*  /.netlify/functions/:splat  200
+/*      /index.html                 200

--- a/public/scripts/app.js
+++ b/public/scripts/app.js
@@ -9,6 +9,6 @@ const renderApp = () => {
   render(app(), document.body);
 };
 
-window.addEventListener('auth', renderApp);
+window.addEventListener('nav', renderApp);
 
 renderApp();

--- a/public/scripts/authenticatedApp.js
+++ b/public/scripts/authenticatedApp.js
@@ -1,10 +1,15 @@
 import { html } from 'https://unpkg.com/lit-html?module';
 
+import router from './templates/router.js';
 import todos from './templates/todos.js';
 import { logOut } from './services/auth.js';
 
+const routes = {
+  '/': todos,
+};
+
 const authenticatedApp = () => html`
-  ${todos()}
+  ${router(routes)}
   <button @click=${logOut} type="button">Log Out</button>
 `;
 

--- a/public/scripts/services/auth.js
+++ b/public/scripts/services/auth.js
@@ -1,10 +1,6 @@
 import { post } from '../utils/api.js';
+import { navigate } from '../utils/navigation.js';
 import { removeSessionToken, setSessionToken } from '../utils/session.js';
-
-/**
- * Custom event fired when authentication status changes.
- */
-const authEvent = new CustomEvent('auth');
 
 export const logIn = async (username, password) => {
   const { data: session, error } = await post('/sessions', {
@@ -21,11 +17,11 @@ export const logIn = async (username, password) => {
 
   setSessionToken(session.token);
 
-  window.dispatchEvent(authEvent);
+  navigate('/');
 };
 
 export const logOut = () => {
   removeSessionToken();
 
-  window.dispatchEvent(authEvent);
+  navigate('/login');
 };

--- a/public/scripts/templates/login.js
+++ b/public/scripts/templates/login.js
@@ -1,0 +1,10 @@
+import { html } from 'https://unpkg.com/lit-html?module';
+
+import loginForm from './loginForm.js';
+
+const login = () => html`
+  <h1>Log in to <strong>Netlify Demo</strong></h1>
+  ${loginForm()}
+`;
+
+export default login;

--- a/public/scripts/templates/notFound.js
+++ b/public/scripts/templates/notFound.js
@@ -1,0 +1,5 @@
+import { html } from 'https://unpkg.com/lit-html?module';
+
+const notFound = () => html`<h1>Not Found</h1>`;
+
+export default notFound;

--- a/public/scripts/templates/router.js
+++ b/public/scripts/templates/router.js
@@ -1,0 +1,10 @@
+import { html } from 'https://unpkg.com/lit-html?module';
+
+import notFound from './notFound.js';
+
+const router = (routes) => {
+  const route = routes[window.location.pathname] || notFound;
+  return html`${route()}`;
+};
+
+export default router;

--- a/public/scripts/unauthenticatedApp.js
+++ b/public/scripts/unauthenticatedApp.js
@@ -1,10 +1,12 @@
 import { html } from 'https://unpkg.com/lit-html?module';
 
-import loginForm from './templates/loginForm.js';
+import login from './templates/login.js';
+import router from './templates/router.js';
 
-const unauthenticatedApp = () => html`
-  <h1>Log in to <strong>Netlify Demo</strong></h1>
-  ${loginForm()}
-`;
+const routes = {
+  '/login': login,
+};
+
+const unauthenticatedApp = () => html`${router(routes)}`;
 
 export default unauthenticatedApp;

--- a/public/scripts/utils/api.js
+++ b/public/scripts/utils/api.js
@@ -1,6 +1,6 @@
 import { getSessionToken } from './session.js';
 
-const baseUrl = '/.netlify/functions';
+const baseUrl = '/api';
 
 const fetch = async (url, method, data) => {
   const headers = new Headers();

--- a/public/scripts/utils/navigation.js
+++ b/public/scripts/utils/navigation.js
@@ -1,0 +1,10 @@
+/**
+ * Custom event fired on navigation.
+ */
+const navEvent = new CustomEvent('nav');
+
+// eslint-disable-next-line import/prefer-default-export
+export const navigate = async (path) => {
+  window.history.pushState({}, '', path);
+  window.dispatchEvent(navEvent);
+};


### PR DESCRIPTION
## Summary

This PR adds client-side routing using the [History API](https://developer.mozilla.org/en-US/docs/Web/API/History_API) and [Netlify redirects](https://docs.netlify.com/routing/redirects/#syntax-for-the-redirects-file).

## Test plan

- [x] Log in
- [x] Log out
- [x] Refresh using F5